### PR TITLE
fix(ci): Code injection

### DIFF
--- a/.github/workflows/verify_pr.yml
+++ b/.github/workflows/verify_pr.yml
@@ -83,8 +83,10 @@ jobs:
 
       - name: Fail job if checks failed
         if: steps.branch.outputs.head_ref_branch == 'main' || steps.semantic-check.outcome == 'failure'
+        env:
+          HEAD_REF_BRANCH: ${{ steps.branch.outputs.head_ref_branch }}
         run: |
-          if [[ "${{ steps.branch.outputs.head_ref_branch }}" == "main" ]]; then
+          if [[ "$HEAD_REF_BRANCH" == "main" ]]; then
             echo "- 分支检查失败: PR 来自 main 分支"
           fi
           if [[ "${{ steps.semantic-check.outcome }}" == "failure" ]]; then


### PR DESCRIPTION
Potential fix for [https://github.com/baiyao105/XTC-ThemePro/security/code-scanning/1](https://github.com/baiyao105/XTC-ThemePro/security/code-scanning/1)

To fix the code injection vulnerability, we should avoid directly interpolating `${{ steps.branch.outputs.head_ref_branch }}` into the shell command. Instead, set it as an environment variable in the step, and reference it using shell-native syntax (`$HEAD_REF_BRANCH`). This prevents shell injection because the shell will treat the value as a single argument, regardless of its content. The fix should be applied to the step named "Fail job if checks failed" (lines 85-93). Specifically, add an `env:` block to set `HEAD_REF_BRANCH: ${{ steps.branch.outputs.head_ref_branch }}` and update the shell commands to use `$HEAD_REF_BRANCH` instead of `${{ steps.branch.outputs.head_ref_branch }}`.

No new imports or methods are needed; only the step definition and shell script need to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
